### PR TITLE
Major attributes update and timestamp migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![GitHub release](https://img.shields.io/github/v/release/solarssk/ztm_warsaw)](https://github.com/solarssk/ztm_warsaw/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Home Assistant](https://img.shields.io/badge/Home%20Assistant-%F0%9F%A7%A1-blue)](https://www.home-assistant.io)
+[![HACS](https://img.shields.io/badge/HACS-Default-blue.svg)](https://hacs.xyz/)
+[![Validate with hassfest](https://github.com/solarssk/ztm_warsaw/actions/workflows/hassfest.yaml/badge.svg)](https://github.com/solarssk/ztm_warsaw/actions)
+[![custom_component](https://img.shields.io/badge/type-custom_component-red.svg)](https://github.com/solarssk/ztm_warsaw)
 
 ZTM Warsaw Integration brings real-time public transport departure data from the City of Warsaw API directly into Home Assistant. Whether you're tracking buses, trams, or metro lines, this integration allows you to view live departures at a glance.
 
@@ -12,30 +15,31 @@ ZTM Warsaw Integration brings real-time public transport departure data from the
 
 ## 🔧 Features
 
-- ✅ Get real-time departures for buses, trams, metro, night and local lines.
-- ✅ Supports multiple instances (multiple stops/lines).
-- ✅ Shows current departure in minutes or time (HH:MM).
-- ✅ Select how many upcoming departures to display.
-- ✅ Recognizes special cases: unavailable schedules, night-only lines, weekend gaps.
-- ✅ Fully integrated with Home Assistant UI – easy to set up, no YAML required.
+- ✅ Real-time and static timetable support for buses, trams, metro, night, cemetery, express and local lines.
+- ✅ Supports multiple instances (you can monitor multiple stops and lines).
+- ✅ Displays current or upcoming departure as timestamp (compatible with UI and automations).
+- ✅ Optional display of up to 3 upcoming departures.
+- ✅ Automatically recognizes and handles no-schedule days, seasonal or partial-day routes.
+- ✅ Full Home Assistant UI configuration – no YAML needed.
+- ✅ Custom attributes: stop info, direction, timetable link and contextual notes.
 
 ---
 
 ## 📸 Screenshots
 
 ### Integration Setup
-
 *Add your API key and stop info...*
 
 <div align="center"><img width="478" alt="image" src="https://github.com/user-attachments/assets/9a77591e-5b1a-4fe5-a29d-637d3c9b566c" /></div>
 
----
-
 ### Entity Display
 
+<div align="center"><img width="555" alt="image" src="https://github.com/user-attachments/assets/ef709b81-1575-4718-9c39-f6c135cf3cca" /></div>
+
+### Attributes
 *Example entity showing departures with attributes like time, direction...*
 
-<div align="center"><img width="478" alt="image" src="https://github.com/user-attachments/assets/71121bef-8b58-4245-8f07-9366390262d1" /></div>
+<div align="center"><img width="530" alt="image" src="https://github.com/user-attachments/assets/95cde9db-1182-41ba-9ae6-3187bd6a527c" /></div>
 
 ---
 

--- a/custom_components/ztm_warsaw/__init__.py
+++ b/custom_components/ztm_warsaw/__init__.py
@@ -2,9 +2,14 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .client import ZTMStopClient
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -17,7 +22,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload ZTM Warsaw config entry."""
-    return await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    result = await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    hass.data[DOMAIN].pop(entry.entry_id, None)
+    return result
 
 @callback
 async def _update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/ztm_warsaw/manifest.json
+++ b/custom_components/ztm_warsaw/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/solarssk/ztm_warsaw/issues",
   "requirements": [],
-  "version": "1.0.2"
+  "version": "1.1.0"
 }

--- a/custom_components/ztm_warsaw/sensor.py
+++ b/custom_components/ztm_warsaw/sensor.py
@@ -1,51 +1,91 @@
-from datetime import timedelta, datetime, timezone
 import logging
 import re
+from datetime import datetime, timezone, timedelta
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
 from homeassistant.const import ATTR_ATTRIBUTION
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util.dt import utcnow as ha_utcnow
 
-from .client import ZTMStopClient
+from .const import CONF_DEPARTURES, DOMAIN, CONF_ATTRIBUTION
+
 from .models import ZTMDepartureDataReading
-from .const import CONF_DEPARTURES
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_ATTRIBUTION = "Data provided by the City of Warsaw (api.um.warszawa.pl)"
 SCAN_INTERVAL = timedelta(minutes=1)
+
+LINE_TYPE_MAP = {
+    # Buses
+    "1": "Normal bus",
+    "2": "Normal bus",
+    "3": "Normal periodic bus",
+    "4": "Fast periodic bus",
+    "5": "Fast bus",
+    "6": "Unknown bus",
+    "7": "Zone normal bus",
+    "8": "Zone periodic bus",
+    "9": "Special bus",
+    "C": "Cemetery bus",
+    "E": "Express periodic bus",
+    "L": "Local suburban bus",
+    "N": "Night bus",
+    "Z": "Replacement line",
+    "T": "Tram line",
+    "M": "Metro line",
+    "S": "Urban rail",
+}
+
+def _line_type(line: str) -> str:
+    """Return human‑friendly type of a Warsaw transport line."""
+    # Tram: purely numeric 1‑ or 2‑digit (1‑99)
+    if re.fullmatch(r"[1-9]\d?", line):
+        return "Tram line"
+    # Metro: letter M + single digit (M1, M2 …)
+    if re.fullmatch(r"M\d", line, re.IGNORECASE):
+        return "Metro line"
+    # Urban rail (SKM): S followed by 1‑2 digits (S1 … S20)
+    if re.fullmatch(r"S\d{1,2}", line, re.IGNORECASE):
+        return "Urban rail"
+    # Otherwise treat as bus type based on first character
+    first = line[0].upper()
+    return LINE_TYPE_MAP.get(first, "unknown")
 
 
 class ZTMSensor(SensorEntity):
-    def __init__(
-        self, hass, api_key, stop_id, stop_number, line, name, max_departures, return_type
-    ):
+    def __init__(self, hass, entry_id, stop_id, stop_number, line, name, max_departures):
+        self._hass = hass
+        self._entry_id = entry_id
         self._line = line
         self._stop_id = stop_id
         self._stop_number = stop_number
         self._name = name
-        self._state = None
         self._attributes = {}
         self._max_departures = max_departures
-        self._return_type = return_type
-        self._timetable = []
-        self.client = ZTMStopClient(
-            async_get_clientsession(hass), api_key, stop_id, stop_number, line
-        )
+        # expose as timestamp sensor
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._next_departure = None
         self._attr_unique_id = f"ztm_{line}_{stop_id}_{stop_number}"
+
+        # static line-level attributes
+        self._attributes["Line, Stop ID"] = self._stop_id
+        self._attributes["Line, Stop number"] = self._stop_number
+        self._attributes["Line, Timezone"] = "Europe/Warsaw"
+        self._attributes["Line, Type"] = _line_type(self._line)
 
     @property
     def name(self):
         return self._name
 
     @property
-    def state(self):
-        return self._state
+    def native_value(self):
+        """Return the next departure as a timezone‑aware datetime (or None)."""
+        return self._next_departure
 
     @property
     def icon(self):
-        if re.match(r"^\d{1,2}$", self._line):
+        # Tram 1–99
+        if re.fullmatch(r"[1-9]\d?", self._line):
             return "mdi:tram"
         elif re.match(r"^\d{3}$", self._line):
             return "mdi:bus"
@@ -60,56 +100,96 @@ class ZTMSensor(SensorEntity):
         return "mdi:bus"
 
     @property
-    def unit_of_measurement(self):
-        """Return 'min' only when we have real departures; hide unit on errors/no data."""
-        if self._state in ("No data available", "No departures available"):
-            return None
-        return "min" if self._return_type == "TIME_TO_DEPART" else None
-
-    @property
     def extra_state_attributes(self):
-        return self._attributes
+        """Return attributes, excluding any None values to satisfy recorder."""
+        return {k: v for k, v in self._attributes.items() if v is not None}
 
     async def async_update(self):
-        """Fetch new data from ZTM API and update state + attributes."""
-        try:
-            data = await self.client.get()
-        except Exception as e:
-            _LOGGER.warning("Exception while fetching data: %s", e)
-            self._state = "No data available"
+        """Fetch new data from coordinator and update state + attributes."""
+        coordinator: DataUpdateCoordinator = self._hass.data[DOMAIN][self._entry_id]
+        data = coordinator.data
+        if data is None:
+            _LOGGER.warning("No timetable data available from coordinator")
+            self._next_departure = None
             self._attributes.clear()
             self._attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
             return
 
-        departures = data.departures
+        all_departures = data.departures  # full day timetable
+
+        departures = all_departures
+
+        # Keep only future departures (>= now)
+        now_utc = ha_utcnow()
+        departures = [d for d in departures if d.dt >= now_utc]
+
+        departures = [d for d in departures if d.dt is not None]
+
+        # Find the soonest departure (if any) and expose it as timestamp
+        self._next_departure = departures[0].dt if departures else None
 
         # 2) No departures at all
         if not departures:
-            self._state = "60+"
+            self._next_departure = None
+            # Do not clear all attributes to preserve structure for templates/helpers
+            static_attrs = {
+                k: self._attributes[k]
+                for k in list(self._attributes)
+                if k.startswith("Line, ")
+            }
             self._attributes.clear()
+            self._attributes.update(static_attrs)
             self._attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
-            self._attributes["note"] = "No upcoming schedule available. Please verify on wtp.waw.pl or call 19115 for more information."
+
+            today_str = datetime.now(tz=timezone.utc).astimezone().strftime("%Y-%m-%d")
+            self._attributes["Line, Full timetable"] = f"https://www.wtp.waw.pl/rozklady-jazdy/?wtp_dt={today_str}&wtp_md=3&wtp_ln={self._line}"
+            self._attributes["note"] = "No upcoming schedule available. Please verify on wtp.waw.pl or call 19115."
+
+            # Preserve empty values for expected attributes
+            self._attributes["Upcoming, Headsign"] = "No service"
+            self._attributes["Upcoming, Departure day"] = "Unknown"
+            for seq in range(1, self._max_departures + 1):
+                self._attributes[f"Next {seq}, Headsign"] = "No service"
+                self._attributes[f"Next {seq}, Departure day"] = "Unknown"
+                self._attributes[f"Next {seq}, Departure time"] = "Unknown"
             return
 
-        # 3) Filter to next 60 minutes
-        valid = [d for d in departures if d.time_to_depart <= 60]
-
-        # Set state: minutes until next departure or '60+'
-        if valid:
-            self._state = f"{valid[0].time_to_depart}"
-        else:
-            self._state = "60+"
-
-        # 4) Build attributes: [1] Time, [1] Departure, [1] Direction, ...
-        to_show = departures[: self._max_departures]
+        # Preserve static attributes
+        static_attrs = {
+            k: self._attributes[k]
+            for k in list(self._attributes)
+            if k.startswith("Line, ")
+        }
         self._attributes.clear()
+        self._attributes.update(static_attrs)
         self._attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+        # Add link to full timetable on WTP site for today's date
+        today_str = datetime.now(tz=timezone.utc).astimezone().strftime("%Y-%m-%d")
+        self._attributes["Line, Full timetable"] = f"https://www.wtp.waw.pl/rozklady-jazdy/?wtp_dt={today_str}&wtp_md=3&wtp_ln={self._line}"
 
-        for idx, dep in enumerate(to_show, start=1):
-            time_str = dep.dt.astimezone().strftime("%H:%M")
-            self._attributes[f"[{idx}] Time"] = time_str
-            self._attributes[f"[{idx}] Departure"] = f"{dep.time_to_depart} min"
-            self._attributes[f"[{idx}] Direction"] = dep.kierunek
+        # helper to friendly day
+        today = datetime.now(tz=timezone.utc).astimezone().date()
+        def friendly_day(local_dt):
+            if local_dt.date() == today:
+                return "today"
+            if local_dt.date() == (today + timedelta(days=1)):
+                return "tomorrow"
+            if local_dt.date() == (today - timedelta(days=1)):
+                return "yesterday"
+            return local_dt.strftime("%a")  # Mon, Tue ...
+
+        # Upcoming (current)
+        current = departures[0]
+        local_current = current.dt.astimezone()
+        self._attributes["Upcoming, Headsign"] = current.kierunek
+        self._attributes["Upcoming, Departure day"] = friendly_day(local_current)
+
+        for seq, dep in enumerate(departures[1 : self._max_departures + 1], start=1):
+            local_dt = dep.dt.astimezone()  # convert to system's local tz (Europe/Warsaw)
+            time_str = local_dt.strftime("%H:%M")
+            self._attributes[f"Next {seq}, Headsign"] = dep.kierunek
+            self._attributes[f"Next {seq}, Departure day"] = friendly_day(local_dt)
+            self._attributes[f"Next {seq}, Departure time"] = time_str
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up ZTM sensor from a config entry."""
@@ -117,24 +197,22 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     data = config_entry.data
     options = config_entry.options
 
-    api_key = data["api_key"]
     stop_id = str(data["busstop_id"])
-    stop_nr = str(data["busstop_nr"])
+    stop_number = str(data["busstop_nr"])
     line = data["line"]
     # Use departures option if set, else fallback to initial data
     departures = options.get(CONF_DEPARTURES, data.get(CONF_DEPARTURES, 1))
 
-    identifier = f"Line {line} from {stop_id}/{stop_nr}"
+    identifier = f"Line {line} from {stop_id}/{stop_number}"
 
     entity = ZTMSensor(
         hass=hass,
-        api_key=api_key,
+        entry_id=config_entry.entry_id,
         stop_id=stop_id,
-        stop_number=stop_nr,
+        stop_number=stop_number,
         line=line,
         name=identifier,
         max_departures=departures,
-        return_type="TIME_TO_DEPART"
     )
 
     await entity.async_update()

--- a/custom_components/ztm_warsaw/translations/en.json
+++ b/custom_components/ztm_warsaw/translations/en.json
@@ -18,7 +18,8 @@
       "invalid_api_key": "Invalid API key. Please check your API key provided by the City of Warsaw.",
       "api_http_error": "Could not connect to the City of Warsaw API.",
       "api_connection_error": "Connection error with the City of Warsaw API.",
-      "no_departures": "The selected line is not available for this stop and pole.",
+      "line_not_found": "The specified line was not found for the selected stop ID and stop number.",
+      "no_departures": "There are no departures scheduled for this line at the selected stop today.",
       "no_valid_times": "No valid departure times returned by the API.",
       "unknown": "An unknown error occurred."
     },


### PR DESCRIPTION
This release includes key improvements for the ZTM Warsaw integration:

- Changed state from static text to a proper `timestamp` representing the next departure
- Added support for recognizing "service day" to handle departures past midnight
- Added fallback message (`note`) when no timetable is available instead of showing "Unknown"
- Introduced new attributes:
  - **Upcoming** and **Next N** departures, with:
    - Departure time
    - Departure day (`Today`, `Tomorrow`, or date)
    - Headsign (direction)
  - Flags for first/last departure (temporarily removed in 1.1.0, may return in future)
  - Line metadata: line type (e.g., night, express), stop ID, pole number
  - Full timetable URL as `Line: Full timetable`
- Implemented validation to ensure selected line exists for the given stop and pole
- Improved detection of transport type (bus, tram, metro, SKM) based on line format
- Adjusted internal structure to retain attribute keys even when no data is available
- Updated data refresh interval from once per day to once per hour
- Internal code cleanup and preparation for future migration to `device/service` model