### PR TITLE
Update stop info endpoint URL in ZTMStopClient

### DIFF
--- a/custom_components/ztm_warsaw/client.py
+++ b/custom_components/ztm_warsaw/client.py
@@ -78,7 +78,7 @@ class ZTMStopClient:
         # Endpoint to fetch the timetable for a given stop, line, and post number
         self._endpoint = "https://api.um.warszawa.pl/api/action/dbtimetable_get/"
         # Endpoint to fetch metadata for stops (name, location, etc.)
-        self._stop_info_endpoint = "https://api.um.warszawa.pl/api/action/dbstore_get/"
+        self._stop_info_endpoint = "https://api.um.warszawa.pl/api/action/dbtimetable_get/"
         self._stop_info_data_id = "ab75c33d-3a26-4342-b36a-6e5fef0a3ac3"
         self._data_id = "e923fa0e-d96c-43f9-ae6e-60518c9f3238"  # timetable endpoint id (dbtimetable_get)
         self._timeout = timeout or 20

--- a/custom_components/ztm_warsaw/manifest.json
+++ b/custom_components/ztm_warsaw/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/solarssk/ztm_warsaw/issues",
   "requirements": ["aiohttp"],
-  "version": "1.1.2"
+  "version": "1.1.3"
 }

--- a/custom_components/ztm_warsaw/sensor.py
+++ b/custom_components/ztm_warsaw/sensor.py
@@ -151,7 +151,6 @@ class ZTMSensor(CoordinatorEntity, SensorEntity):
             "manufacturer": "Zarząd Transportu Miejskiego",
             "entry_type": "service",
             "model": get_line_type(self._line),
-            "sw_version": stop_info.get("obowiazuje_od"),
             "configuration_url": self._timetable_url(),
         }
 
@@ -337,8 +336,6 @@ class ZTMSensor(CoordinatorEntity, SensorEntity):
         self._attributes["Stop, Street ID"] = stop_info.get("id_ulicy", "Not available")
         self._attributes["Stop, Latitude"] = stop_info.get("szer_geo", "Not available")
         self._attributes["Stop, Longitude"] = stop_info.get("dlug_geo", "Not available")
-        self._attributes["Stop, Direction"] = stop_info.get("kierunek", "Not available")
-        self._attributes["Stop, Effective From"] = stop_info.get("obowiazuje_od", "Not available")
         self._attributes["Stop, Timezone"] = "Europe/Warsaw"
         self._attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
 
@@ -386,8 +383,6 @@ class ZTMSensor(CoordinatorEntity, SensorEntity):
             self._attributes["Stop, Street ID"] = stop_info.get("id_ulicy", "Not available")
             self._attributes["Stop, Latitude"] = stop_info.get("szer_geo", "Not available")
             self._attributes["Stop, Longitude"] = stop_info.get("dlug_geo", "Not available")
-            self._attributes["Stop, Direction"] = stop_info.get("kierunek", "Not available")
-            self._attributes["Stop, Effective From"] = stop_info.get("obowiazuje_od", "Not available")
         else:
             self._attributes["Stop, Name"] = "Not available"
             self._attributes["Stop, Street ID"] = "Not available"


### PR DESCRIPTION
**Updating the resource in connection with changes in the API from the City of Warsaw**

Changed the _stop_info_endpoint in ZTMStopClient to use the dbtimetable_get endpoint instead of dbstore_get, ensuring consistency with the API usage.