### PR TITLE
Add Mypy type checking workflow and fix reported type errors

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -1,0 +1,20 @@
+name: Mypy
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  mypy:
+    name: Mypy type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mypy aiohttp
+      - run: mypy custom_components/ztm_warsaw --ignore-missing-imports

--- a/custom_components/ztm_warsaw/__init__.py
+++ b/custom_components/ztm_warsaw/__init__.py
@@ -61,6 +61,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         return False
 
+    assert api_key is not None and stop_id is not None and stop_nr is not None and line is not None
+
     session = async_get_clientsession(hass)
 
     client = ZTMStopClient(

--- a/custom_components/ztm_warsaw/client.py
+++ b/custom_components/ztm_warsaw/client.py
@@ -100,8 +100,8 @@ class ZTMStopClient:
             "busstopNr": stop_number,
             "line": line,
         }
-        self._stop_name = None
-        self._stop_info_cache = {}
+        self._stop_name: dict | None = None
+        self._stop_info_cache: dict[tuple[str, str], dict] = {}
 
     async def _get_with_retry(self, url: str, params: dict, *, expect_json: bool = True):
         """Perform GET with timeout and a small retry on timeout/5xx.

--- a/custom_components/ztm_warsaw/config_flow.py
+++ b/custom_components/ztm_warsaw/config_flow.py
@@ -15,7 +15,7 @@ from .const import DOMAIN, CONF_API_KEY, CONF_BUSSTOP_ID, CONF_BUSSTOP_NR, CONF_
 
 _LOGGER = logging.getLogger(__name__)
 
-TIMEOUT = 20  # seconds
+TIMEOUT = aiohttp.ClientTimeout(total=20)
 RETRIES = 1   # number of retries for timeout/5xx during validation
 BACKOFF = 1.5 # seconds backoff multiplier
 

--- a/custom_components/ztm_warsaw/config_flow.py
+++ b/custom_components/ztm_warsaw/config_flow.py
@@ -150,7 +150,7 @@ async def validate_input(api_key, stop_id, stop_nr, line):
         _LOGGER.exception("Unexpected error during validation: %s", e)
         raise ValueError("unknown")
 
-class ZtmWarsawConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class ZtmWarsawConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
     VERSION = 1
 
     async def async_step_user(self, user_input=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.mypy]
+python_version = "3.12"
+ignore_missing_imports = true
+warn_unused_ignores = true


### PR DESCRIPTION
- Add .github/workflows/mypy.yaml to run on every push and PR
- Add pyproject.toml with mypy config targeting Python 3.12
- Annotate _stop_name and _stop_info_cache with proper types in client.py
- Add assert guard before ZTMStopClient/Coordinator instantiation in __init__.py
- Suppress false positive in config_flow.py (HA metaclass unknown to mypy)