### PR TITLE
Release 1.1.4 — stability, performance and CI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,10 @@ ZTM Warsaw Integration brings real-time public transport departure data from the
 
 ### Installation via HACS:
 
-> 🧪 Until reviewed and officially included in HACS, you can add this integration manually as a custom repository.
-
 1. In Home Assistant, go to **HACS → Integrations**.
-2. Click the three dots in the top-right corner and choose **Custom repositories**.
-3. Paste this repository URL:  
-   `https://github.com/solarssk/ztm_warsaw`
-4. Set category to **Integration** and confirm.
-5. Find and install the **Warsaw Public Transport** integration from the list.
-6. Restart Home Assistant.
+2. Search for **Warsaw Public Transport**.
+3. Click **Download** and confirm.
+4. Restart Home Assistant.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,13 +5,13 @@
 
 ## 1. Supported Versions
 
-I actively maintain **only the latest major branch (1.x)**.  
-Older branches receive *no* patches, even for severe issues.
+I actively maintain **only the latest release**.  
+Older versions receive *no* patches, even for severe issues.
 
-| Version | Status | Notes                      |
-|---------|--------|----------------------------|
-| `1.x`   | ✅ **Supported** | Bug & security fixes |
-| `< 1.0` | ❌ **End-of-Life** | Please upgrade      |
+| Version   | Status | Notes                      |
+|-----------|--------|----------------------------|
+| `1.1.4`   | ✅ **Supported** | Current stable release |
+| `< 1.1.4` | ❌ **End-of-Life** | Please upgrade      |
 
 If you discover a vulnerability while running an EOL version, upgrade first and confirm it also exists in the current release before filing a report.
 
@@ -79,4 +79,4 @@ This integration merely **reads** publicly available information from the City o
 
 ---
 
-*Last updated: 2025-04-26* | Maintainer: **@solarssk**
+*Last updated: 2026-05-20* | Maintainer: **@solarssk**

--- a/custom_components/ztm_warsaw/__init__.py
+++ b/custom_components/ztm_warsaw/__init__.py
@@ -109,7 +109,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     stored = hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
-    if stored and (coord := stored.get("coordinator")):
+    if isinstance(stored, dict):
+        coord = stored.get("coordinator")
+    elif isinstance(stored, ZTMStopCoordinator):
+        coord = stored
+    else:
+        coord = None
+    if coord:
         try:
             await coord.async_shutdown()
         except Exception:  # noqa: BLE001 - shutdown should not crash unload

--- a/custom_components/ztm_warsaw/client.py
+++ b/custom_components/ztm_warsaw/client.py
@@ -112,10 +112,15 @@ class ZTMStopClient:
             try:
                 async with async_timeout.timeout(self._timeout):
                     async with self._session.get(url, params=params, allow_redirects=True) as resp:
-                        if resp.content_length and resp.content_length > 2_000_000:
-                            _LOGGER.error("Response too large (%d bytes) from %s; skipping", resp.content_length, url)
-                            return None
-                        text = await resp.text()
+                        chunks: list[bytes] = []
+                        total = 0
+                        async for chunk in resp.content:
+                            total += len(chunk)
+                            if total > 2_000_000:
+                                _LOGGER.error("Response too large (>2 MB) from %s; skipping", url)
+                                return None
+                            chunks.append(chunk)
+                        text = b"".join(chunks).decode(resp.charset or "utf-8", errors="replace")
                         # Retry on 5xx
                         if 500 <= resp.status <= 599 and attempt < self._max_retries:
                             _LOGGER.warning(

--- a/custom_components/ztm_warsaw/client.py
+++ b/custom_components/ztm_warsaw/client.py
@@ -114,7 +114,7 @@ class ZTMStopClient:
                     async with self._session.get(url, params=params, allow_redirects=True) as resp:
                         chunks: list[bytes] = []
                         total = 0
-                        async for chunk in resp.content:
+                        async for chunk in resp.content.iter_chunked(65536):
                             total += len(chunk)
                             if total > 2_000_000:
                                 _LOGGER.error("Response too large (>2 MB) from %s; skipping", url)

--- a/custom_components/ztm_warsaw/client.py
+++ b/custom_components/ztm_warsaw/client.py
@@ -112,6 +112,9 @@ class ZTMStopClient:
             try:
                 async with async_timeout.timeout(self._timeout):
                     async with self._session.get(url, params=params, allow_redirects=True) as resp:
+                        if resp.content_length and resp.content_length > 2_000_000:
+                            _LOGGER.error("Response too large (%d bytes) from %s; skipping", resp.content_length, url)
+                            return None
                         text = await resp.text()
                         # Retry on 5xx
                         if 500 <= resp.status <= 599 and attempt < self._max_retries:

--- a/custom_components/ztm_warsaw/config_flow.py
+++ b/custom_components/ztm_warsaw/config_flow.py
@@ -199,7 +199,10 @@ class ZtmWarsawOptionsFlow(config_entries.OptionsFlow):
         schema = vol.Schema({
             vol.Optional(
                 CONF_DEPARTURES,
-                default=self._config_entry.options.get(CONF_DEPARTURES, 1)
+                default=self._config_entry.options.get(
+                    CONF_DEPARTURES,
+                    self._config_entry.data.get(CONF_DEPARTURES, 1),
+                )
             ): vol.In({
                 1: "Next departure",
                 2: "Next two departures",

--- a/custom_components/ztm_warsaw/manifest.json
+++ b/custom_components/ztm_warsaw/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/solarssk/ztm_warsaw/issues",
   "requirements": ["aiohttp"],
-  "version": "1.1.4b5"
+  "version": "1.1.4b6"
 }

--- a/custom_components/ztm_warsaw/sensor.py
+++ b/custom_components/ztm_warsaw/sensor.py
@@ -77,7 +77,6 @@ class ZTMSensor(CoordinatorEntity, SensorEntity):
         # Initialize attributes and state
         self._attributes = {}
         self._next_departure = None
-        self._previous_departure = None
         self._scheduled_unsub = None
         self._last_coordinator_update = None
 
@@ -269,7 +268,6 @@ class ZTMSensor(CoordinatorEntity, SensorEntity):
         # No future departures and not hiding — clear next departure
         if not future_departures:
             _LOGGER.info("No future departures found for %s", self.entity_id)
-            self._previous_departure = self._next_departure
             self._next_departure = None
             self._set_no_departures()
             _write_if_changed()
@@ -300,7 +298,6 @@ class ZTMSensor(CoordinatorEntity, SensorEntity):
         
         # Update next departure
         new_departure = future_departures[0].dt
-        self._previous_departure = self._next_departure
         self._next_departure = new_departure
         
         _LOGGER.info("Next departure for %s: %s → %s", 
@@ -380,12 +377,8 @@ class ZTMSensor(CoordinatorEntity, SensorEntity):
         self._attributes["Note"] = "No upcoming schedule available. Please verify on wtp.waw.pl or call 19115."
         self._attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
 
-        # Update state if changed
         if self._next_departure is not None:
-            self._previous_departure = None
             self._next_departure = None
-        else:
-            self._previous_departure = None
 
     async def async_will_remove_from_hass(self):
         """Cancel any scheduled listener when removing."""
@@ -471,12 +464,23 @@ class ZTMLastUpdateSensor(CoordinatorEntity, SensorEntity):
         departures_count = 0
         if self.coordinator.data and hasattr(self.coordinator.data, 'departures'):
             departures_count = len(self.coordinator.data.departures or [])
-        
+
         return {
             "Last update successful": getattr(self.coordinator, 'last_update_success', False),
             "Number of fetched departures": departures_count,
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
         }
+
+    @callback
+    def _handle_coordinator_update(self):
+        """Update friendly name with stop name when coordinator data arrives."""
+        stop_info = self._get_stop_info()
+        stop_name = stop_info.get("nazwa_zespolu")
+        if stop_name:
+            new_name = f"Line {self._line} {stop_name} {self._stop_number} Last update"
+            if self._attr_name != new_name:
+                self._attr_name = new_name
+        self.async_write_ha_state()
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/info.md
+++ b/info.md
@@ -69,15 +69,10 @@ ZTM Warsaw Integration brings real-time public transport departure data from the
 
 ### Installation via HACS:
 
-> 🧪 Until reviewed and officially included in HACS, you can add this integration manually as a custom repository.
-
 1. In Home Assistant, go to **HACS → Integrations**.
-2. Click the three dots in the top-right corner and choose **Custom repositories**.
-3. Paste this repository URL:  
-   `https://github.com/solarssk/ztm_warsaw`
-4. Set category to **Integration** and confirm.
-5. Find and install the **Warsaw Public Transport** integration from the list.
-6. Restart Home Assistant.
+2. Search for **Warsaw Public Transport**.
+3. Click **Download** and confirm.
+4. Restart Home Assistant.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR consolidates all improvements developed on the `dev` branch for the `1.1.4` stable release.

### Network resilience
- Added retry logic for `aiohttp.ClientError` (in addition to existing timeout retries)
- Coordinator now serves cached data on API failure instead of going unavailable
- Fixed `aiohttp.ClientTimeout` type in config flow (was bare `int`)
- Added 2 MB response size cap to prevent memory exhaustion on unexpected API payloads

### Entity & dashboard
- Fixed `entity_id` generation — now always uses numeric stop IDs (e.g. `sensor.line_28_from_7009_03`), regardless of whether the stop name is available
- Removed redundant `async_write_ha_state()` calls — state is only written when departure data actually changes
- Removed per-minute tick — sensors self-schedule exact callbacks at each departure time, reducing HA dashboard load

### Configuration
- Options flow now correctly falls back to `entry.data` when options have not been set yet
- Integration reloads automatically when options are changed via the UI

### Code quality
- Added Ruff linting workflow (CI)
- Added Mypy type checking workflow (CI, Python 3.12)
- Removed dead code: unused variables, redundant imports, unreachable branches
- Updated HACS installation instructions — integration is now in the default HACS repository

### Security
- API key is masked in all log output
- `SECURITY.md` updated: `1.1.4` marked as the only supported version

## Test plan
- [ ] Install on Home Assistant and add a new entity — verify `entity_id` is numeric
- [ ] Disconnect network briefly — verify sensor does not go unavailable, resumes after reconnect
- [ ] Change number of departures via Configure — verify integration reloads and applies new setting
- [ ] Check HA logs — verify no API key appears in plain text
