### PR TITLE
Fix coordinator shutdown to cancel update interval

### DIFF
--- a/custom_components/ztm_warsaw/coordinator.py
+++ b/custom_components/ztm_warsaw/coordinator.py
@@ -110,4 +110,5 @@ class ZTMStopCoordinator(DataUpdateCoordinator):
     async def async_shutdown(self):
         """Clean up when coordinator is being shut down."""
         self.data = None
+        await super().async_shutdown()
         _LOGGER.info("ZTM Coordinator [%s] — shutdown complete", self.name)


### PR DESCRIPTION
## Summary

- Call `super().async_shutdown()` in `ZTMStopCoordinator` so the base `DataUpdateCoordinator` properly cancels its hourly refresh timer on unload. Without this, the timer was leaking on every options change / integration reload.

## Test plan
- [x] Change number of departures via Configure — verify no duplicate refreshes in logs after clean HA restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)