### PR TITLE
Fix sensor setup: use coordinator from hass.data instead of creating …

### DIFF
--- a/custom_components/ztm_warsaw/coordinator.py
+++ b/custom_components/ztm_warsaw/coordinator.py
@@ -109,6 +109,9 @@ class ZTMStopCoordinator(DataUpdateCoordinator):
 
     async def async_shutdown(self):
         """Clean up when coordinator is being shut down."""
+        if getattr(self, "_ztm_shutdown_done", False):
+            return
+        self._ztm_shutdown_done = True
         self.data = None
         await super().async_shutdown()
         _LOGGER.info("ZTM Coordinator [%s] — shutdown complete", self.name)

--- a/custom_components/ztm_warsaw/sensor.py
+++ b/custom_components/ztm_warsaw/sensor.py
@@ -11,10 +11,8 @@ from homeassistant.core import callback
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import EntityCategory
 
-from .client import ZTMStopClient
 from .const import CONF_DEPARTURES, DOMAIN, CONF_ATTRIBUTION
 from .coordinator import ZTMStopCoordinator
 
@@ -486,40 +484,17 @@ class ZTMLastUpdateSensor(CoordinatorEntity, SensorEntity):
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up ZTM sensor from a config entry."""
     try:
-        # Read configuration and options
-        data = config_entry.data
-        options = config_entry.options
+        stored = hass.data[DOMAIN][config_entry.entry_id]
+        coordinator: ZTMStopCoordinator = stored["coordinator"] if isinstance(stored, dict) else stored
 
-        stop_id = str(data["busstop_id"])
-        stop_number = str(data["busstop_nr"])
-        line = data["line"]
-        # Use departures option if set, else fallback to initial data
+        options = config_entry.options
+        data = config_entry.data
         departures = options.get(CONF_DEPARTURES, data.get(CONF_DEPARTURES, 1))
 
-        # Create session and client
-        session = async_get_clientsession(hass)
-        client = ZTMStopClient(
-            session=session,
-            api_key=data["api_key"],
-            stop_id=stop_id,
-            stop_number=stop_number,
-            line=line,
-        )
+        stop_id = coordinator.stop_id
+        stop_number = coordinator.stop_nr
+        line = coordinator.line
 
-        # Create coordinator
-        coordinator = ZTMStopCoordinator(
-            hass=hass,
-            client=client,
-            stop_id=stop_id,
-            stop_nr=stop_number,
-            line=line,
-        )
-
-        # Initialize coordinator
-        await coordinator.async_config_entry_first_refresh()
-        hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = coordinator
-
-        # Create entities
         entity = ZTMSensor(
             coordinator=coordinator,
             entry_id=config_entry.entry_id,
@@ -536,12 +511,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             stop_number=stop_number,
         )
 
-        entities = [entity, diag_sensor]
+        async_add_entities([entity, diag_sensor])
 
-        # Add entities
-        async_add_entities(entities)
-        
-        _LOGGER.info("Successfully set up ZTM sensors for line %s at stop %s/%s", 
+        _LOGGER.info("Successfully set up ZTM sensors for line %s at stop %s/%s",
                     line, stop_id, stop_number)
 
     except Exception as e:


### PR DESCRIPTION
…a new one

sensor.py was creating its own coordinator and client, independent of __init__.py. This caused double initial refresh, double API calls on startup, and the legacy storage format bug (bare coordinator overwriting the dict stored by __init__). Sensor now reads the coordinator created by __init__.py from hass.data.